### PR TITLE
Fix polygon rendering and canvas display on iOS Safari

### DIFF
--- a/fractals/polygon_fractals/polygon_fractals.html
+++ b/fractals/polygon_fractals/polygon_fractals.html
@@ -205,6 +205,7 @@
             max-height: 100%;
             width: 100%;
             height: auto;
+            aspect-ratio: 1 / 1;
             display: block;
             margin: 0 auto;
             /* Enhanced iOS Safari SVG optimizations */
@@ -255,6 +256,7 @@
             #fractal-svg {
                 width: auto;
                 height: auto;
+                aspect-ratio: 1 / 1;
                 max-width: 100%;
                 max-height: 100%;
             }
@@ -344,6 +346,7 @@
             #fractal-svg {
                 width: 100% !important;
                 height: auto !important;
+                aspect-ratio: 1 / 1 !important;
                 max-width: 100% !important;
                 display: block !important;
                 margin: 0 auto !important;
@@ -451,6 +454,7 @@
             #fractal-svg {
                 width: 100% !important;
                 height: auto !important;
+                aspect-ratio: 1 / 1 !important;
                 max-width: 100% !important;
                 display: block !important;
                 margin: 0 auto !important;
@@ -482,6 +486,7 @@
                 width: 100% !important;
                 max-width: 100% !important;
                 height: auto !important;
+                aspect-ratio: 1 / 1 !important;
                 display: block !important;
                 margin: 0 auto !important;
                 /* Additional iOS Safari SVG fixes */
@@ -524,6 +529,7 @@
                 -webkit-font-smoothing: antialiased;
                 text-rendering: geometricPrecision;
                 shape-rendering: geometricPrecision;
+                aspect-ratio: 1 / 1;
             }
             
             /* Touch-friendly controls for iOS */
@@ -960,9 +966,8 @@
                 this.svg.selectAll("*").remove();
                 
                 // Setup SVG with enhanced iOS Safari optimizations
+                // Do not set explicit width/height attributes; rely on viewBox + CSS for responsive sizing
                 this.svg
-                    .attr("width", this.width)
-                    .attr("height", this.height)
                     .attr("viewBox", `0 0 ${this.width} ${this.height}`)
                     .attr("preserveAspectRatio", "xMidYMid meet")
                     .style("display", "block")

--- a/index.html
+++ b/index.html
@@ -79,6 +79,12 @@
                 <p>Ancient Indian numerical encoding system demonstrated through the ordering of 72 Melakartha ragas in Carnatic music.</p>
                 <a href="elementary/katapayadi_sankhya/katapayadi_sankhya.html">View Visualization</a>
             </div>
+
+            <div class="viz-card">
+                <h3>Polygon Fractals</h3>
+                <p>Interactive nested polygon animation with mobile-friendly SVG rendering.</p>
+                <a href="fractals/polygon_fractals/polygon_fractals.html">View Visualization</a>
+            </div>
         </div>
     </div>
 </body>


### PR DESCRIPTION
Improve SVG rendering and canvas sizing on iOS Safari by implementing `aspect-ratio` and `viewBox` for responsive scaling.

---
<a href="https://cursor.com/background-agent?bcId=bc-bf3cd5b8-738c-4bb8-b0a3-0e03de833611">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bf3cd5b8-738c-4bb8-b0a3-0e03de833611">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

